### PR TITLE
fix(auth/history): 修复历史记录保存与字段映射不一致问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bcryptjs": "^3.0.3",
     "chardet": "^2.1.1",
     "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "file-type": "^21.3.0",
     "framer-motion": "^12.27.5",
     "geist": "^1.5.1",

--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -368,11 +368,14 @@ export const POST = withDatabase(
             )
           }
 
+          // 计算总评分并添加到结果中
+          const score = calculateOverallScore(parsedResult.dimensions)
+          parsedResult.overallScore = score
+
           // 加密并存储结果 (仅对已登录用户)
           if (userId && password) {
             let saveClient: MongoClient | undefined
             try {
-              const score = calculateOverallScore(parsedResult.dimensions)
               const encryptedResult = await encryptObject(
                 parsedResult,
                 password

--- a/src/app/api/dashboard/history/route.ts
+++ b/src/app/api/dashboard/history/route.ts
@@ -40,7 +40,6 @@ export const GET = withDatabase(async (req: NextRequest, db) => {
     // 返回加密的记录
     const resultHistories = histories.map((history: any) => ({
       id: history._id.toString(),
-      encryptedContent: history.encryptedContent,
       encryptedResult: history.encryptedResult,
       mode: history.mode,
       createdAt: history.createdAt

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -167,15 +167,11 @@ export default function DashboardPage() {
         const decryptedHistories = await Promise.all(
           rawHistories.map(async (h: any) => {
             try {
-              const content = h.encryptedContent
-                ? await decrypt(h.encryptedContent, password)
-                : null
               const resultStr = h.encryptedResult
                 ? await decrypt(h.encryptedResult, password)
                 : null
               return {
                 id: h.id,
-                content,
                 result: resultStr ? JSON.parse(resultStr) : null,
                 mode: h.mode,
                 createdAt: h.createdAt
@@ -642,10 +638,6 @@ export default function DashboardPage() {
                             {history.error ? (
                               <p className="text-sm text-red-600">
                                 {history.error}
-                              </p>
-                            ) : history.content ? (
-                              <p className="text-sm text-muted-foreground line-clamp-2">
-                                {history.content}
                               </p>
                             ) : null}
                           </Card>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -130,9 +130,10 @@ export default function RegisterPage() {
         throw new Error(data.error || '注册失败')
       }
 
-      // 保存token
+      // 保存token和密码
       localStorage.setItem('auth_token', data.token)
       localStorage.setItem('username', data.user.username)
+      localStorage.setItem('user_password', password)
 
       // 跳转到dashboard
       router.push('/dashboard')


### PR DESCRIPTION
## 📋 Purpose

修复用户注册/登录后历史记录无法正常保存的核心问题，统一加密存储字段为 `encryptedResult`，移除冗余的 `encryptedContent`，完善认证流程确保用户密码正确存储。

## 🔧 Changes

### API 层改动
- **src/app/api/analyze/route.ts**:
  * 将 `calculateOverallScore` 结果添加到 `parsedResult.overallScore`
  * 调整评分计算时机，确保返回数据包含完整评分信息

- **src/app/api/dashboard/history/route.ts**:
  * 移除 `encryptedContent` 字段引用，统一使用 `encryptedResult`

### 前端改动
- **src/app/dashboard/page.tsx**:
  * 移除对 `content` 的解密和展示逻辑，仅保留 `result` 字段
  * 简化历史记录卡片展示，移除未使用的内容预览

- **src/app/register/page.tsx**:
  * 注册成功后保存 `user_password` 到 `localStorage`
  * 与登录流程保持一致，确保历史记录加密可用

### 依赖改动
- **package.json**:
  * 添加 `clsx@^2.1.1` 依赖

## ✨ Impact

- ✅ 修复历史记录保存失败问题
- ✅ 统一数据结构，减少字段混淆
- ✅ 改善用户体验，注册后立即可使用历史功能
- ⚠️ 需确保 `.env` 中配置了 `MONGODB_URI` 和 `JWT_SECRET`